### PR TITLE
enhancement: scroll the precip graph to the present on mobile (issue #1)

### DIFF
--- a/app/assets/javascripts/landing_controller.js
+++ b/app/assets/javascripts/landing_controller.js
@@ -179,6 +179,8 @@ LandingController.prototype.renderGraph = function (intervals) {
             timeSeriesChart.update();
         }
     });
+
+    $(".graph .overflow-wrapper").scrollLeft(1000);
 }
 
 LandingController.prototype._parseDailyIntervalsForGraph = function (intervals) {


### PR DESCRIPTION
Programmatically scrolling the graph's wrapper container the number of pixels defined by `$mobileBreakpoint` (1000px) from the left edge ensures that the graph's canvas will always be anchored on its right side to its wrapper.  This does not affect desktop container/canvas positioning in accordance with issue #1 acceptance criteria.

Though this addresses the issue, I personally don't think it provides the best UX as the y-axis tick labels ("inches of precip") are no longer visible by default.  To address this you could place y-axis on both side of the chart though this also would provide poor UX as people are not accustomed to reading charts in this manner.  A better option would be to reconfigure the layout of the chart for mobile screens altogether (using the same dependency, chartjs 2.7.x), which I can take a stab at if you are willing to revisit.

Also completely unrelated but I'm not a Ruby/Rails person but it seems that perhaps the official Ruby Docker images are pulling some dependencies without pinned versions, including some gem/lib called 'activesupport'.  A major release, 7.0, seems to have been tagged in middle of December.  The ruby 2.6 image appears to be pulling this 7.0 active support version which requires ruby 2.7+, so the Docker images won't build as is (unless I am missing something as I am using Mac OSX Big Sur).  My local solution was to bump the ruby Docker image to 2.7 and make the associated change in the Gemfile.